### PR TITLE
Fix runtime error on Windows 10.

### DIFF
--- a/gate/src/core/sdl/mod.rs
+++ b/gate/src/core/sdl/mod.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 use std::fs::File;
 use std::io::BufReader;
 
-use sdl2::{self, VideoSubsystem};
+use sdl2::{self, hint, VideoSubsystem};
 use sdl2::video::{FullscreenType, GLProfile};
 use sdl2::video::gl_attr::GLAttr;
 use sdl2::image::LoadTexture;
@@ -56,6 +56,8 @@ macro_rules! gate_header {
 pub fn run<AS: AppAssetId, AP: App<AS>>(info: AppInfo, mut app: AP) {
     mark_app_created_flag();
 
+    #[cfg(target_os = "windows")]
+    hint::set("SDL_RENDER_DRIVER", "opengles2");
     let sdl_context = sdl2::init().unwrap();
     let video = sdl_context.video().unwrap();
     let _sdl_audio = sdl_context.audio().unwrap();


### PR DESCRIPTION
This PR fixes the `OpenGL texture binding not supported` error on Windows 10. It does this by setting an SDL hint to use the `opengles2` renderer.

Note: This error occurs both when running Chirperjax (See [Chirperjax: Issue #2](https://github.com/SergiusIW/chirperjax/issues/2)) and when running the gate example project.

The idea for the fix came from [this post](https://discourse.libsdl.org/t/sdl2-opengl-in-golang-glbind-sdl-gl-bindtexture-panic/25631/2) in the SDL forums:

> I think it has something to do with the kind of video driver SDL2 is using behind the scenes.
> Ran into the same problem. However, on my Windows 10 when I specify…

> `SDL_SetHint(SDL_HINT_RENDER_DRIVER,"opengles2");`

> …before calling SDL_Init then binding the texture works, albeit with the RGB channels swapped.
> Also interesting, with and without the hint it answers it is using the windows driver when asked about (by calling SDL_GetCurrentVideoDriver).

The hint is only compiled in on Windows to avoid changing the renderer used on any other platform.