### PR TITLE
Shrink unsafe blocks

### DIFF
--- a/gate/src/core/sdl/core_audio.rs
+++ b/gate/src/core/sdl/core_audio.rs
@@ -40,14 +40,14 @@ impl CoreAudio {
     }
 
     pub fn play_music(&mut self, music: u16, loops: bool) {
-        unsafe {
+        
             self.stop_music();
             let loops = if loops { -1 } else { 1 };
             let music = CString::new(format!("assets/music{}.ogg", music)).unwrap();
-            let music = Mix_LoadMUS(music.as_ptr());
-            Mix_PlayMusic(music, loops);
+            let music = unsafe {Mix_LoadMUS(music.as_ptr())};
+            unsafe {Mix_PlayMusic(music, loops)};
             self.music = Some(music);
-        }
+        
     }
 
     pub fn stop_music(&mut self) {

--- a/gate/src/renderer/core_renderer/sdl/shader_util.rs
+++ b/gate/src/renderer/core_renderer/sdl/shader_util.rs
@@ -19,8 +19,8 @@ use gl::types::*;
 use gl;
 
 pub fn compile_shader(src: *const c_char, ty: GLenum) -> GLuint {
+    let shader = unsafe {gl::CreateShader(ty)};
     unsafe {
-        let shader = gl::CreateShader(ty);
 
         gl::ShaderSource(shader, 1, &src, ptr::null());
         gl::CompileShader(shader);
@@ -36,13 +36,13 @@ pub fn compile_shader(src: *const c_char, ty: GLenum) -> GLuint {
             gl::GetShaderInfoLog(shader, len, ptr::null_mut(), buf.as_mut_ptr() as *mut GLchar);
             panic!("{}", str::from_utf8(&buf).ok().expect("glGetShaderInfoLog returned invalid utf8"));
         }
-        shader
     }
+        shader
 }
 
 pub fn link_program(vs: GLuint, fs: GLuint) -> GLuint {
+    let program = unsafe {gl::CreateProgram()};
     unsafe {
-        let program = gl::CreateProgram();
         gl::AttachShader(program, vs);
         gl::AttachShader(program, fs);
         gl::LinkProgram(program);
@@ -58,6 +58,6 @@ pub fn link_program(vs: GLuint, fs: GLuint) -> GLuint {
             gl::GetProgramInfoLog(program, len, ptr::null_mut(), buf.as_mut_ptr() as *mut GLchar);
             panic!("{}", str::from_utf8(&buf).ok().expect("glGetProgramInfoLog returned invalid utf8"));
         }
-        program
     }
+    program
 }


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html