### PR TITLE
Mark run function as unsafe

### DIFF
--- a/gate/src/lib.rs
+++ b/gate/src/lib.rs
@@ -86,7 +86,7 @@ pub fn run<AS, AP, F>(info: AppInfo, app: F) where
     let previously_created = APP_CREATED.swap(true, Ordering::Relaxed);
     assert!(!previously_created, "Cannot run more than one App.");
 
-    core::run(info, app);
+    unsafe { core::run(info, app) };
 }
 
 /// Trait that a user can implement to specify application behavior, passed into `gate::run(...)`.


### PR DESCRIPTION
https://github.com/SergiusIW/gate/blob/ffa72fc5e9691edf2ed2a62d8c27913c6d89458a/gate/src/core/sdl/mod.rs#L53-L134
Hello, it is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the start function may not notice this safety requirement.

Marking them unsafe also means that callers must make sure they know what they're doing.